### PR TITLE
MNT: Remove forced ocaml *_4 - Awaiting automated pick of latest build (odd)

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  build_number: 1
+  build_number: 2
   name: ocaml-dune
   version: "3.22.1"
 
@@ -27,7 +27,6 @@ build:
 requirements:
   build:
     - ${{ compiler("ocaml") }}
-    - ocaml >=5.4.0 *_4
     - ${{ m2 }}bash >=5.2
     - ${{ m2 }}gawk
     - ${{ m2 }}grep


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
